### PR TITLE
Update PRTG-CrowdStrike.ps1

### DIFF
--- a/PRTG-CrowdStrike.ps1
+++ b/PRTG-CrowdStrike.ps1
@@ -145,6 +145,18 @@ if(-not ((Test-FalconToken).Token))
         </result>"
 #End Region Quarantine
 
+# Start Region Duplicates
+    $HostsDuplicates = Find-FalconDuplicate
+    $HostsDuplicatesCount = ($HostsDuplicates.hostname).count
+        
+    $xmlOutput = $xmlOutput + "<result>
+        <channel>Hosts Duplicates</channel>
+        <value>$($HostsDuplicatesCount)</value>
+        <unit>Count</unit>
+        <limitmode>1</limitmode>
+        <LimitMaxError>0</LimitMaxError>
+        </result>"
+#End Region Duplicates
 
 #Start Region Clients
     $Hosts_Total = Get-FalconHost -Total


### PR DESCRIPTION
Hello Janos,

I've write a small PRTG EXE script in January to check if there are hosts duplicates in Falcon, but only count the duplicates.
This is usefull because sometimes after upgrade the endpoints for example from Win10 to Win11, Falcon create duplicates.
For sure I'm not a "script guy" like you, would be nice if you can integrate and adding the hostname duplicate, I try to show with `<text>` tag, but again I'm not good with the script!

My best regards